### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -3,6 +3,9 @@ name: Build and test
 on:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/DBC-Works/p5js-packer/security/code-scanning/1](https://github.com/DBC-Works/p5js-packer/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow. Since the workflow only checks out the code, sets up Node.js, installs dependencies, and runs tests and builds, it only needs `contents: read` permission. This ensures that the workflow does not have unnecessary write access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
